### PR TITLE
Ensure character birth century

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,3 +18,21 @@ task "jobs:work" => "resque:work"
 task :test do
   Dir['./spec/**/*_spec.rb'].each { |f| load f }
 end
+
+desc "Adds missing centuries to birth dates (example: 0020 to 2020)"
+task "cleanup_birth" do
+  characters = Character.where(({'birth' => {'$lt' => Date.parse('1999-01-01')}}) )
+
+  puts "Found #{characters.count}"
+
+  puts "Updating..." if characters.count > 0
+
+  characters.each do |character|
+    with_century = DateHelper::ensure_century(character['birth'])
+
+    character.update(birth: with_century)
+  end
+
+  puts "Done"
+
+end

--- a/helpers/account_helper.rb
+++ b/helpers/account_helper.rb
@@ -775,7 +775,4 @@ module AccountHelper
     field.length == 1 ? field.first[:value] : Proc.new { "" }
   end
 
-  def self.parse_birth(birth)
-    DateTime.strptime("#{birth} EST", "%m/%d/%Y %H:%M:%S %p %Z")
-  end
 end

--- a/helpers/account_helper.rb
+++ b/helpers/account_helper.rb
@@ -39,7 +39,7 @@ module AccountHelper
       :name => "birth",
       :label => "Birth",
       :group => :general,
-      :value => Proc.new { |v| v[:birth] }
+      :value => Proc.new { |v| DateHelper::ensure_century(v[:birth]) }
     },
     {
       :name => "aetheria",

--- a/helpers/character_helper.rb
+++ b/helpers/character_helper.rb
@@ -8,30 +8,6 @@ module CharacterHelper
     "self" => "Self"
   }
 
-  def self.parse_birth(birth)
-    parsed = nil
-
-    # Try our first format
-    begin
-      parsed = DateTime.strptime("#{birth} EST", "%m/%d/%Y %H:%M:%S %p %Z")
-    rescue ArgumentError
-      puts "ArgumentError caught trying to parse '#{birth} EST' as a DateTime with format %m/%d/%Y %H:%M:%S %p %Z"
-      puts "Error was `#{$!}`"
-    end
-
-    # Try our second one
-    if parsed.nil?
-      begin
-        parsed = DateTime.strptime("#{birth} EST", "%m/%d/%Y %H:%M:%S %Z")
-      rescue ArgumentError
-        puts "ArgumentError caught trying to parse '#{birth} EST' as a DateTime with format %m/%d/%Y %H:%M:%S %Z"
-        puts "Error was `#{$!}`"
-      end
-    end
-
-    DateHelper::ensure_century(parsed)
-  end
-
   def self.tag_html(character)
     html_strings = []
     html_strings << "<div class='tag'>" # Open up tag div

--- a/helpers/character_helper.rb
+++ b/helpers/character_helper.rb
@@ -29,7 +29,7 @@ module CharacterHelper
       end
     end
 
-    parsed
+    DateHelper::ensure_century(parsed)
   end
 
   def self.tag_html(character)

--- a/helpers/date_helper.rb
+++ b/helpers/date_helper.rb
@@ -1,0 +1,8 @@
+module DateHelper
+
+  def self.ensure_century(date)
+    adjustment = (date.year < 1999) ? 2000 : 0
+    date + adjustment.years
+  end
+
+end

--- a/helpers/date_helper.rb
+++ b/helpers/date_helper.rb
@@ -1,5 +1,10 @@
 module DateHelper
 
+  FORMATS = [
+    "%m/%d/%Y %H:%M:%S %p %Z",
+    "%m/%d/%Y %H:%M:%S %Z"
+  ]
+
   def self.ensure_century(date)
     return if date.nil?
 
@@ -8,27 +13,17 @@ module DateHelper
   end
 
   def self.parse(date_string)
-    parsed = nil
-
-    # Try our first format
-    begin
-      parsed = DateTime.strptime("#{date_string} EST", "%m/%d/%Y %H:%M:%S %p %Z")
-    rescue ArgumentError
-      puts "ArgumentError caught trying to parse '#{date_string} EST' as a DateTime with format %m/%d/%Y %H:%M:%S %p %Z"
-      puts "Error was `#{$!}`"
-    end
-
-    # Try our second one
-    if parsed.nil?
+    results = FORMATS.lazy.map do |format|
       begin
-        parsed = DateTime.strptime("#{date_string} EST", "%m/%d/%Y %H:%M:%S %Z")
+        parsed = DateTime.strptime("#{date_string} EST", format)
+        ensure_century(parsed)
       rescue ArgumentError
-        puts "ArgumentError caught trying to parse '#{date_string} EST' as a DateTime with format %m/%d/%Y %H:%M:%S %Z"
+        puts "ArgumentError caught trying to parse '#{date_string} EST' as a DateTime with format #{format}"
         puts "Error was `#{$!}`"
       end
     end
 
-    ensure_century(parsed)
+    results.detect { |date| !date.nil? }
   end
 
 end

--- a/helpers/date_helper.rb
+++ b/helpers/date_helper.rb
@@ -7,4 +7,28 @@ module DateHelper
     date + adjustment.years
   end
 
+  def self.parse(date_string)
+    parsed = nil
+
+    # Try our first format
+    begin
+      parsed = DateTime.strptime("#{date_string} EST", "%m/%d/%Y %H:%M:%S %p %Z")
+    rescue ArgumentError
+      puts "ArgumentError caught trying to parse '#{date_string} EST' as a DateTime with format %m/%d/%Y %H:%M:%S %p %Z"
+      puts "Error was `#{$!}`"
+    end
+
+    # Try our second one
+    if parsed.nil?
+      begin
+        parsed = DateTime.strptime("#{date_string} EST", "%m/%d/%Y %H:%M:%S %Z")
+      rescue ArgumentError
+        puts "ArgumentError caught trying to parse '#{date_string} EST' as a DateTime with format %m/%d/%Y %H:%M:%S %Z"
+        puts "Error was `#{$!}`"
+      end
+    end
+
+    ensure_century(parsed)
+  end
+
 end

--- a/helpers/date_helper.rb
+++ b/helpers/date_helper.rb
@@ -6,8 +6,6 @@ module DateHelper
   ]
 
   def self.ensure_century(date)
-    return if date.nil?
-
     adjustment = (date.year < 1999) ? 2000 : 0
     date + adjustment.years
   end

--- a/helpers/date_helper.rb
+++ b/helpers/date_helper.rb
@@ -1,6 +1,8 @@
 module DateHelper
 
   def self.ensure_century(date)
+    return if date.nil?
+
     adjustment = (date.year < 1999) ? 2000 : 0
     date + adjustment.years
   end

--- a/helpers/rankings_helper.rb
+++ b/helpers/rankings_helper.rb
@@ -463,7 +463,7 @@ module RankingsHelper
       :match => { "a" => { "$exists" => true }, "b" => { "$ne" => nil } },
       :project => { "_id" => 0, "n" => 1, "s" => 1, "b" => 1 },
       :sort => { "b" => 1 },
-      :accessor => Proc.new { |v| v["b"] }
+      :accessor => Proc.new { |v| DateHelper::ensure_century(v["b"]) }
     },
     :deaths => {
       :display => "Deaths",

--- a/routes/server.rb
+++ b/routes/server.rb
@@ -62,7 +62,10 @@ module Sinatra
             end
 
             content_type 'application/json'
-            JSON.pretty_generate(@character.serializable_hash({}).tap {|h| h.delete("id")})
+            JSON.pretty_generate(@character.serializable_hash({}).tap do |h|
+              h.delete("id")
+              h['birth'] = DateHelper::ensure_century(h['birth'])
+            end)
           end
 
           app.get '/:server/:name/?' do |s,n|

--- a/routes/upload.rb
+++ b/routes/upload.rb
@@ -67,7 +67,7 @@ module Sinatra
 
             # Convert "birth" field so it's stored as DateTime with GMT-5
             if(json_text.has_key?("birth"))
-              json_text["birth"] = CharacterHelper::parse_birth(json_text["birth"])
+              json_text["birth"] = DateHelper::parse(json_text["birth"])
             end
 
             # Log extra debug info if birth ends up being nil

--- a/spec/unit/date_helper_spec.rb
+++ b/spec/unit/date_helper_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../spec_helper'
+require './helpers/date_helper'
+
+describe DateHelper do
+  describe '.ensure_century' do
+    before do
+      date = Date.strptime(date_string, '%m/%d/%Y')
+      @result = DateHelper.ensure_century(date)
+    end
+
+    describe 'when date string contains century' do
+      let(:date_string) { '10/07/2021' }
+
+      it 'returns date with correct century' do
+        assert_equal(2021, @result.year)
+      end
+    end
+
+    describe 'when date string does NOT contain century' do
+      let(:date_string) { '10/07/21' }
+
+      it 'returns date with correct century' do
+        assert_equal(2021, @result.year)
+      end
+    end
+  end
+end

--- a/views/_other_pane.haml
+++ b/views/_other_pane.haml
@@ -4,7 +4,7 @@
       %td.specialized{:colspan => 2} General
     %tr
       %td Birth
-      %td= @character.birth
+      %td= DateHelper::ensure_century(@character.birth)
     %tr
       %td Deaths
       %td= @character.deaths


### PR DESCRIPTION
Issue: https://github.com/amoeba/treestats.net/issues/193

### Root cause
Modern uploads from emulators appear to be uploading some birth dates with no century. For example, `01/01/20` is uploaded instead of `01/01/2020`. Treestats.net expects format `%m/%d/%Y` seen [here](https://github.com/amoeba/treestats.net/blob/4dc8a0f4ef081302a244e1fdb22fd6e166aaea29/helpers/character_helper.rb#L16)

`Date.strptime` returns a year of `0020` which reproduces the issue.

```
require 'date'
Date.strptime("01/01/20", "%m/%d/%Y")
# => #<Date: 0020-01-01 ((1728363j,0s,0n),+0s,2299161j)>
```

### Solutions

There's three parts to the solution:
- Write: Add century to dates as new records are uploaded
- Read: Add century to dates before rendering (html and json) existing records.
- Cleanup: Find all Character's with missing centuries and update the records.

**NOTE:** I've solved all three, but you can pair the "Write"  and "Cleanup" solutions while omitting the "Read" solution if you like. This will make the diff much smaller.

### Points of interest (main branch)
Here's all the locations in the code for reading and writing. Let me know if there I've missed any.

For writing (1) :
  - https://github.com/amoeba/treestats.net/blob/4dc8a0f4ef081302a244e1fdb22fd6e166aaea29/routes/upload.rb#L69-L79

For reading (4):
  - Account page: https://github.com/amoeba/treestats.net/blob/4dc8a0f4ef081302a244e1fdb22fd6e166aaea29/helpers/account_helper.rb#L42
  - Rankings page: https://github.com/amoeba/treestats.net/blob/4dc8a0f4ef081302a244e1fdb22fd6e166aaea29/helpers/rankings_helper.rb#L466
  - Character page (Other pane): https://github.com/amoeba/treestats.net/blob/4dc8a0f4ef081302a244e1fdb22fd6e166aaea29/views/_other_pane.haml#L7
  - Character JSON output: https://github.com/amoeba/treestats.net/blob/4dc8a0f4ef081302a244e1fdb22fd6e166aaea29/routes/server.rb#L65

### Cleanup
Run `bundle exec rake cleanup_birth`
Sample output:
```
Found 1
Updating...
Done
```
The task can be re-run to ensure it finds `0`.