### PR TITLE
Fix Aetheria Slot display

### DIFF
--- a/helpers/account_helper.rb
+++ b/helpers/account_helper.rb
@@ -45,7 +45,7 @@ module AccountHelper
       :name => "aetheria",
       :label => "Aetheria",
       :group => :general,
-      :value => Proc.new { |v| v[:properties]["322"]}
+      :value => Proc.new { |v| PropertiesHelper::AETHERIA_SLOTS[v[:properties]["322"]] }
     },
     {
       :name => "times_enlightened",

--- a/helpers/properties_helper.rb
+++ b/helpers/properties_helper.rb
@@ -86,6 +86,13 @@ module PropertiesHelper
     # "246" => { :type => :resist, :name => "Piercing Resistance"}
   }
 
+  AETHERIA_SLOTS = {
+    0 => 0,
+    1 => 1,
+    3 => 2,
+    7 => 3
+  }
+
   MASTERY_NAMES = {
     '354' => {
         1 => "Unarmed",

--- a/views/_other_pane.haml
+++ b/views/_other_pane.haml
@@ -9,11 +9,13 @@
       %td Deaths
       %td= @character.deaths
     - @character.properties.each do |k,v|
-    - next unless PropertiesHelper::is_type(k, :general)
+      - next unless PropertiesHelper::is_type(k, :general)
       %tr
         %td= PropertiesHelper::get_property_name(k)
         -if k == "199"
           %td= Time.at(v.to_i + 4 * 60 * 60).utc
+        -elsif k == "322"
+          %td= PropertiesHelper::AETHERIA_SLOTS[v]
         -else
           %td= v
     - if @character.properties


### PR DESCRIPTION
Issue: https://github.com/amoeba/treestats.net/issues/201

The Aetheria slots property is currently showing the bitmask as an integer (0,1,3,7).

Changes:
- Define mapping to correct count.
- Lookup count on the Character page (other pane)
- Lookup count on the Account page

Screenshots (tested using property 322 value of 7)

<img width="355" alt="treestats_aetheria_character" src="https://user-images.githubusercontent.com/1517368/137735980-315a5097-db72-4328-931b-357fc6208bdd.png">

<img width="301" alt="treestats_aetheria_account" src="https://user-images.githubusercontent.com/1517368/137735990-69cddbe3-83b1-451b-b17b-06475b58ef0d.png">

