### PR TITLE
Rate limiting

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -28,6 +28,7 @@ end
 class TreeStats < Sinatra::Base
   configure :production do
     use Sentry::Rack::CaptureExceptions
+    use RateLimiter, limit: 100, seconds: 60
   end
 
   set :root, File.dirname(__FILE__)

--- a/lib/rate_limiter.rb
+++ b/lib/rate_limiter.rb
@@ -1,0 +1,37 @@
+require "redis"
+
+class RateLimiter
+  def initialize(app, options = {})
+    @app = app
+    @limit = options[:limit] || 100
+    @seconds = options[:seconds] || 60
+    @redis = Redis.new
+  end
+
+  def call(env)
+    ip = env['REMOTE_ADDR']
+    key = build_key(ip)
+
+    count = increment(key)
+
+    if count > @limit
+      [429, { 'Content-Type' => 'text/plain' }, ['Rate limit exceeded']]
+    else
+      @app.call(env)
+    end
+  end
+
+  private
+
+  def build_key(ip)
+    "rate_limiter:#{ip}:#{Time.now.to_i / @seconds}"
+  end
+
+  def increment(key)
+    count = @redis.incr(key)
+
+    @redis.expire(key, @seconds) if count == 1
+
+    count
+  end
+end


### PR DESCRIPTION
To config, edit `use RateLimiter, limit: 100, seconds: 60` in  `app.rb`. The default is 100 requests per 60 seconds per IP address.

To test, Run in production mode. `RACK_ENV=production rackup config.ru`

Here's a log when using  `use RateLimiter, limit: 2, seconds: 15`

```
127.0.0.1 - - [09/Jan/2024:18:59:31 -0500] "GET / HTTP/1.1" 200 34396 0.3447
127.0.0.1 - - [09/Jan/2024:18:59:34 -0500] "GET / HTTP/1.1" 200 34396 0.1299
127.0.0.1 - - [09/Jan/2024:18:59:35 -0500] "GET / HTTP/1.1" 429 19 0.0022

127.0.0.1 - - [09/Jan/2024:19:00:01 -0500] "GET / HTTP/1.1" 200 34396 0.1048
127.0.0.1 - - [09/Jan/2024:19:00:02 -0500] "GET / HTTP/1.1" 200 34396 0.1015
127.0.0.1 - - [09/Jan/2024:19:00:03 -0500] "GET / HTTP/1.1" 429 19 0.0021
```
<img width="246" alt="Screenshot 2024-01-09 185623" src="https://github.com/amoeba/treestats.net/assets/1517368/b3759268-834f-4f96-afbd-e2663cac283c">

