### PR TITLE
docs: update README with beta player counts chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ And the entire allegiance tree, drawn as a force-directed graph (again, as it is
 
 ![Allegiance tree viewer](docs/tree.png)
 
+TreeStats also tracks server population over time. A redesigned beta player counts chart (powered by D3.js) is available at `/player_counts_beta/` and is accessible via a banner on the main player counts page.
+
 
 One limitation of TreeStats is that it only knows about monarchs, patrons, and vassals of the characters that are directly uploaded (i.e. what is on your Allegiance pane). It won't know about the characters in between unless those players upload their characters using the plugin directly.
 


### PR DESCRIPTION
## Documentation update

This PR updates the README to reflect the new beta player counts chart redesign introduced in f49f711abc8d80566659cc51840d4805a19f6202.

### Code change that triggered this update

- **[f49f711](https://github.com/amoeba/treestats.net/commit/f49f711abc8d80566659cc51840d4805a19f6202)** — *add beta player counts chart redesign* (March 15, 2026)
  - Added a new D3.js-powered player counts chart at `/player_counts_beta/`
  - Added a beta banner on the existing `/player_counts/` page linking to the new chart
  - Added `/player_counts_all.json` endpoint (Redis-cached, 24h TTL)

### What changed in docs

- `README.md`: Added a sentence in the "What TreeStats Does" section noting the beta player counts chart and its URL, consistent with how the README already highlights D3.js visualizations.

### Skipped (not significant enough)

- *bundle update* — dependency bump only
- *Disable rack protection* — internal fix for 403s, no user-facing behavior change
- *Try to improve caching* — internal optimization
- *Sync servers (#245)* — automated server list update

_This PR was generated with [Oz](https://warp.dev/oz)._
